### PR TITLE
Fix classifiers

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -15,8 +15,6 @@ CLASSIFIERS = ['Topic :: Scientific/Engineering :: Astronomy',
                 'License :: OSI Approved :: GNU General Public License v3 (GPLv3)',
                 'Natural Language :: English',
                 'Programming Language :: Python :: 2.7',
-                'Programming Language :: Python :: 2 :: Only',
-                'Programming Language :: Python :: 3 :: Only',
                 'Programming Language :: Python :: 3.5']
 
 


### PR DESCRIPTION
The current release claims to support only Python 2, and only Python 3, which is a contradiction.

https://pypi.org/search/?q=&o=&c=Programming+Language+%3A%3A+Python+%3A%3A+2+%3A%3A+Only&c=Programming+Language+%3A%3A+Python+%3A%3A+3+%3A%3A+Only
